### PR TITLE
Another round of pulling up dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ maintenance = { status = "actively-developed" }
 proc_macro = true
 
 [dependencies]
-proc-macro2 = "0.4.15"
-syn = { version = "0.14.9", features = ["visit", "extra-traits"] }
+proc-macro2 = "0.4.20"
+syn = { version = "0.15", features = ["visit", "extra-traits"] }
 quote = "0.6.8"
 
 [dev-dependencies]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,12 +18,14 @@ pub fn slog_attributes(attrs: &[Attribute]) -> Vec<Meta> {
         .filter_map(|meta| match meta {
             Meta::List(list) => Some(list),
             _ => None,
-        }).filter(|meta_list| meta_list.ident == SLOG_ATTRIBUTE)
+        })
+        .filter(|meta_list| meta_list.ident == SLOG_ATTRIBUTE)
         .flat_map(|ml| ml.nested)
         .filter_map(|nested| match nested {
             NestedMeta::Meta(m) => Some(m),
             _ => None,
-        }).collect()
+        })
+        .collect()
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
Only `syn` this time.
And smallish rustfmt

If you accept this PR, can you please release a new version to crates.io?
