### PR TITLE
Don't pass reference to emit_serde

### DIFF
--- a/src/derive_serde_value.rs
+++ b/src/derive_serde_value.rs
@@ -22,7 +22,7 @@ pub fn impl_serde_value(ast: DeriveInput) -> TokenStream2 {
         let value_impl = quote! {
             impl ::slog::Value for #name {
                 fn serialize(&self, _record: &::slog::Record, key: ::slog::Key, ser: &mut dyn ::slog::Serializer) -> ::slog::Result {
-                    ser.emit_serde(&key, self)
+                    ser.emit_serde(key, self)
                 }
             }
         };


### PR DESCRIPTION
`emit_serde` takes a `Key` but this library is passing `&Key`, since `Key` is usually `&'static str` this is usually fine because the compiler will automatically dereference it to the correct type, but breaks when the `dynamic-keys` feature is enabled in slog.